### PR TITLE
Redesign script.

### DIFF
--- a/nspawn
+++ b/nspawn
@@ -23,18 +23,55 @@
 # Github: www.github.com/shibumi
 
 set -e
-BASEURL="https://nspawn.org/storage/"
+VERSION="0.1"
+STATIC_NAME="Nspawn (https://nspawn.org)"
+
+BASEURL="https://nspawn.org/storage"
 LISTURL="https://nspawn.org/storage/list.txt"
 KEYLOCATION="https://nspawn.org/storage/masterkey.pgp"
-TYPES=("raw" "tar")
-DISTRIBUTIONS=("archlinux" "debian" "ubuntu" "fedora" "centos")
-RELEASES=("archlinux" "buster" "jessie" "stretch" "28" "29" "30" "7" "6"
-  "xenial" "bionic")
+
+ctrl_c() {
+  echo "Keyboard Interrupt detected, leaving."
+  echo
+  summary
+  exit
+}
+
+trap ctrl_c 2
+
+version() {
+  echo "$STATIC_NAME $VERSION"
+}
+
+helpout() {
+  echo "Menu usage for $STATIC_NAME $VERSION"
+  echo
+  echo "$0 {COMMAND} [PARAMETER]"
+  echo
+  echo "Wrapper around systemd-machined and https://nspawn.org"
+  echo
+  echo "Commands:"
+  echo -e "  -i/--init          \tInitializes an image for systemd-machined with the following parameters: <distribution>/<release>/<type>"
+  echo -e "  -l/--list          \tLists all available images"
+  echo -e "  -h/--help          \tPrints this help message"
+  echo -e "  -v/--version       \tPrints version info"
+  echo
+  echo "Parameters:"
+  echo -e "  <distribution>\tOne out of (archlinux,centos,debian,fedora,ubuntu)"
+  echo -e "  <release>     \tThe release of the distribution"
+  echo -e "  <type>        \tOne out of (raw,tar)"
+
+}
+
+if [[ $# -eq 0 ]]; then
+  helpout
+  exit
+fi
 
 escalate_privilege() {
   if [ "$EUID" -ne 0 ]; then
     echo "nspawn needs root privileges for the following action:"
-    echo "  $1"
+    echo " $1"
     exit 1
   fi
 }
@@ -43,83 +80,81 @@ if ! [ -f "/etc/systemd/import-pubring.gpg" ]; then
   echo "/etc/systemd/import-pubring.gpg does not exist"
   read -rp "Do you want to create it [y/n]: " choice
   case "$choice" in
-    y | Y)
-      escalate_privilege "Setting up the GPG keyring"
-      gpg --no-default-keyring --keyring=/etc/systemd/import-pubring.gpg --fingerprint
-      tfile=$(mktemp -u /tmp/masterkey.nspawn.org.XXXXXXXXXXX)
-      curl "$KEYLOCATION" -o "$tfile"
-      gpg --no-default-keyring --keyring=/etc/systemd/import-pubring.gpg --import "$tfile"
-      ;;
-    n | N)
-      exit 2
-      ;;
-    *)
-      exit 2
-      ;;
+  y | Y)
+    escalate_privilege "Setting up the GPG keyring"
+    gpg --no-default-keyring --keyring=/etc/systemd/import-pubring.gpg --fingerprint
+    tfile=$(mktemp -u /tmp/masterkey.nspawn.org.XXXXXXXXXXX)
+    curl "$KEYLOCATION" -o "$tfile"
+    gpg --no-default-keyring --keyring=/etc/systemd/import-pubring.gpg --import "$tfile"
+    ;;
+  n | N)
+    exit 2
+    ;;
+  *)
+    exit 2
+    ;;
   esac
 fi
 
-array_contains() {
-  local e match="$1"
-  shift
-  for e; do [[ "$e" == "$match" ]] && return 0; done
-  return 1
-}
-
-helpout() {
-  echo "nspawn {COMMAND} [PARAMETER]"
-  echo ""
-  echo "Wrapper around systemd-machined and https://nspawn.org"
-  echo ""
-  echo "Commands:"
-  echo -e "  init          \tInitializes an image for systemd-machined with the following parameters: <distribution>/<release>/<type>"
-  echo -e "  list          \tLists all available images"
-  echo -e "  help          \tPrints this help message"
-  echo ""
-  echo "Parameters:"
-  echo -e "  <distribution>\tOne out of (archlinux,centos,debian,fedora,ubuntu)"
-  echo -e "  <release>     \tThe release of the distribution"
-  echo -e "  <type>        \tOne out of (raw,tar)"
-
+list() {
+  curl "$LISTURL"
 }
 
 init() {
   distribution=$(echo "$1" | cut -d"/" -f1)
   release=$(echo "$1" | cut -d"/" -f2)
   type=$(basename "$1")
-  if array_contains "$type" "${TYPES[@]}"; then
-    if array_contains "$distribution" "${DISTRIBUTIONS[@]}"; then
-      if array_contains "$release" "${RELEASES[@]}"; then
-        escalate_privilege "pulling the image via machinectl-$type"
-        machinectl pull-"$type" "$BASEURL$distribution/$release/$type/image.$type.xz" "$distribution-$release-$type" 2> /dev/null
-      else
-        echo "Wrong release, try 'nspawn list' to list all possible releases for this distribution"
-      fi
+  image_url="$BASEURL/$distribution/$release/$type/image.$type.xz"
+  output_image="$distribution-$release-$type"
+  check_image_location=$(curl -o /dev/null -sIw '%{http_code}' "$image_url")
+  if [[ $check_image_location -eq 200 ]]; then
+    if machinectl show-image "$output_image" &>/dev/null; then
+      echo "Machine $output_image already exists. Details:"
+      echo
+      machinectl show-image "$output_image"
+      echo
+      exit
+    fi
+    escalate_privilege "Pulling the image via machinectl-$type..."
+    if machinectl pull-"$type" "$image_url" "$output_image" 2>/dev/null; then
+      echo
+      echo "Image deployed locally as $output_image, details:"
+      echo
+      machinectl show-image "$output_image"
+      echo
     else
-      echo "Wrong distribution, needs to be one of (archlinux,centos,debian,fedora,ubuntu)"
+      echo "Error while deploying image."
     fi
   else
-    echo "Wrong type, needs to be one of (raw,tar)"
+    echo "Error: $check_image_location. Wrong type, distribution or release in $output_image. Try 'nspawn list'."
   fi
-
 }
 
-list() {
-  curl "$LISTURL"
-}
-
-case $1 in
-  init)
-    if [ $# -eq 2 ]; then
-      init "$2"
-    else
-      helpout
-    fi
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+  -v | --version)
+    version
+    exit
     ;;
-  list)
+  -h | --help)
+    helpout
+    exit
+    ;;
+  -l | --list)
     list
+    exit
+    ;;
+  -i | --init)
+    init "$2"
+    shift
+    shift
     ;;
   *)
-    helpout
+    POSITIONAL+=("$1")
+    shift
     ;;
-esac
+  esac
+done
+set -- "${POSITIONAL[@]}"


### PR DESCRIPTION
- Avoid harcoding versions, distros and types for the checks.
- There was a problem with fedora 32 where the version was not in the VERSIONS array and the script failed still when the image existed in the repos.
- Better arguments handling. With the actual approach it's easy to add new options.
- Check if the image exists remotely with curl instead of checking hardcoded arrays.
- Check if the image already exists locally and inform the user.
- Give details to user about the image when deployed locally.