### PR TITLE
Remove path from usage/help

### DIFF
--- a/nspawn
+++ b/nspawn
@@ -47,7 +47,7 @@ version() {
 helpout() {
   echo "Menu usage for $STATIC_NAME $VERSION"
   echo
-  echo "$0 {COMMAND} [PARAMETER]"
+  echo "${0##*/} {COMMAND} [PARAMETER]"
   echo
   echo "Wrapper around systemd-machined and https://nspawn.org"
   echo

--- a/nspawn-builder
+++ b/nspawn-builder
@@ -62,7 +62,7 @@ check_mkosi() {
 helpout() {
   echo "Menu usage for $STATIC_NAME $VERSION"
   echo
-  echo "$0 {COMMAND} [PARAMETER]"
+  echo "${0##*/} {COMMAND} [PARAMETER]"
   echo
   echo "Wrapper around mkosi for creating images in https://nspawn.org"
   echo "If you find an issue, report it to: https://github.com/nspawn/nspawn"


### PR DESCRIPTION
Avoids output like

```
/home/swick/repos/vaporup/nspawn/nspawn {COMMAND} [PARAMETER]
```

or

```
./nspawn {COMMAND} [PARAMETER]
```

Now it always shows

```
nspawn {COMMAND} [PARAMETER]
```